### PR TITLE
Adding definition for RXCn for Atmega 8

### DIFF
--- a/src/DMXSerial_avr.h
+++ b/src/DMXSerial_avr.h
@@ -36,6 +36,7 @@
 // These definitions are used on ATmega8 boards
 #define UCSRnA UCSRA // Control and Status Register A
 #define TXCn TXC // Transmit buffer clear
+#define RXCn RXC
 
 #define UCSRnB UCSRB // USART Control and Status Register B
 


### PR DESCRIPTION
Added the required definition for RXCn for the Atmega 8 as it was missing, which caused a compilation error.
This change solves the error.