### PR TITLE
Added URSEL flag to fix ATMEGA8 functionality

### DIFF
--- a/src/DMXSerial.cpp
+++ b/src/DMXSerial.cpp
@@ -55,10 +55,22 @@ typedef enum {
 // receiver must accept 88 us break and 8 us MAB
 #define BREAKSPEED 100000L
 
+#if !defined(DMX_USE_PORT1) && defined(USART_RXC_vect)
+
+// ATMEGA8 requires that URSEL be set to 1 when writing to register UCSRC
+// This definition appends the required bit to the serial definition
+
+#define BREAKFORMAT (SERIAL_8E2 | (1<<URSEL))
+#define DMXFORMAT (SERIAL_8N2 | (1<<URSEL))
+#define DMXREADFORMAT (SERIAL_8N1 | (1<<URSEL))
+
+#else
+
 #define BREAKFORMAT SERIAL_8E2
 #define DMXFORMAT SERIAL_8N2
 #define DMXREADFORMAT SERIAL_8N1
 
+#endif
 
 // ----- include processor specific definitions and functions.
 


### PR DESCRIPTION
As documented on page 150 of the [ATMEGA8 datasheet](https://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-2486-8-bit-AVR-microcontroller-ATmega8_L_datasheet.pdf), bit 7 of the UCSRC register must be set to 1 in order to write to register UCSRC; otherwise, writes are directed to register UBRRH. Adding a preprocessor macro to identify compilation for the ATMEGA8, and adding the required flag has resolved the issue of this library failing to execute in my case. I have only validated functionality for DMX read functionality at this time.